### PR TITLE
hotfix: add volume information to klay price data in front

### DIFF
--- a/module-domain/src/main/kotlin/io/klaytn/finder/service/FinderHomeService.kt
+++ b/module-domain/src/main/kotlin/io/klaytn/finder/service/FinderHomeService.kt
@@ -87,6 +87,7 @@ class FinderHomeService(
         usdPrice = BigDecimal(klayPrice["usdPrice"] ?: defaultKlayPrice),
         btcPrice = BigDecimal(klayPrice["btcPrice"] ?: defaultKlayPrice),
         usdPriceChanges = BigDecimal(klayPrice["usdPercentChange24h"] ?: defaultKlayPrice),
+        volume = BigDecimal(klayPrice["volume24h"] ?: defaultKlayPrice),
         marketCap = BigDecimal(klayPrice["usdMarketCap"] ?: defaultKlayPrice),
         totalSupply = BigDecimal(klayPrice["usdTotalSupply"] ?: defaultKlayPrice),
     )

--- a/module-domain/src/main/kotlin/io/klaytn/finder/view/model/FinderHome.kt
+++ b/module-domain/src/main/kotlin/io/klaytn/finder/view/model/FinderHome.kt
@@ -25,6 +25,7 @@ data class FinderKlayPrice(
         @Schema(title = "Klay Dollar Price Change Ratio") val usdPriceChanges: BigDecimal,
         @Schema(title = "Market Cap") val marketCap: BigDecimal,
         @Schema(title = "Total Supply") val totalSupply: BigDecimal,
+        @Schema(title = "Klay Dollar Volume 24h") val volume: BigDecimal,
 )
 
 @Schema


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added display of "Klay Dollar Volume 24h" in the Finder Home service to provide users with daily trading volume information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->