### PR TITLE
Implement api endpoint for fetching gc info

### DIFF
--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/GovernanceCouncilController.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/GovernanceCouncilController.kt
@@ -1,0 +1,23 @@
+package io.klaytn.finder.interfaces.rest.api
+
+import io.klaytn.finder.infra.ServerMode
+import io.klaytn.finder.infra.web.swagger.SwaggerConstant
+import io.klaytn.finder.service.GovernanceCouncilInfoService
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@Profile(ServerMode.API_MODE)
+@RestController
+@Tag(name = SwaggerConstant.TAG_PUBLIC)
+class GovernanceCouncilController(
+    val governanceCouncilInfoService: GovernanceCouncilInfoService
+) {
+    //TODO : Newly Joined API
+    //TODO : Category - Governance Council
+    @GetMapping("/api/v1/governance-councils")
+    fun governanceCouncilInfo() = governanceCouncilInfoService.getAll()
+    //TODO : Detail API
+
+}

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/GovernanceCouncilController.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/GovernanceCouncilController.kt
@@ -14,10 +14,6 @@ import org.springframework.web.bind.annotation.RestController
 class GovernanceCouncilController(
     val governanceCouncilInfoService: GovernanceCouncilInfoService
 ) {
-    //TODO : Newly Joined API
-    //TODO : Category - Governance Council
     @GetMapping("/api/v1/governance-councils")
     fun governanceCouncilInfo() = governanceCouncilInfoService.getAll()
-    //TODO : Detail API
-
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
@@ -42,12 +42,17 @@ class GovernanceCouncilToListViewMapper(
 
         return governanceCouncilInfoMap.map { (squareId, governanceCouncilInfo) ->
             val governanceCouncilCategories =
-                governanceCouncilCategoriesMap[squareId]?.map { GovernanceCouncilCategory(it.categoryId, it.categoryName) } ?: emptyList()
+                governanceCouncilCategoriesMap[squareId]?.map {
+                    GovernanceCouncilCategory(
+                        it.categoryId,
+                        it.categoryName
+                    )
+                } ?: emptyList()
             GovernanceCouncilWithCategoryView(
-                squareId = squareId,
                 name = governanceCouncilInfo.name,
                 squareLink = governanceCouncilInfo.squareLink,
                 thumbnail = governanceCouncilInfo.thumbnail,
+                joinedAt = governanceCouncilInfo.joinedAt,
                 totalStaking = governanceCouncilInfo.totalStaking,
                 apy = governanceCouncilInfo.apy,
                 description = governanceCouncilInfo.description,

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
@@ -9,6 +9,7 @@ import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.Governa
 import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.GovernanceCouncilWithCategoryView
 import io.klaytn.finder.service.governancecouncil.GovernanceCouncilService
 import org.springframework.stereotype.Component
+import io.klaytn.commons.utils.logback.logger
 
 @Component
 class GovernanceCouncilToViewMapper(
@@ -34,6 +35,8 @@ class GovernanceCouncilToViewMapper(
 @Component
 class GovernanceCouncilToListViewMapper(
 ) : Mapper<Pair<List<GovernanceCouncilsInfo>, List<GovernanceCouncilCategories>>, List<GovernanceCouncilWithCategoryView>> {
+    private val logger = logger(this::class.java)
+
     override fun transform(source: Pair<List<GovernanceCouncilsInfo>, List<GovernanceCouncilCategories>>): List<GovernanceCouncilWithCategoryView> {
         val (governanceCouncilInfoList, governanceCouncilCategoriesList) = source
 
@@ -57,9 +60,14 @@ class GovernanceCouncilToListViewMapper(
     }
 
     private fun mapCategories(categories: List<GovernanceCouncilCategories>): List<GovernanceCouncilCategory> {
-        return categories.map {
-            GovernanceCouncilCategory(it.categoryId, it.categoryName)
-        }
+        return try {
+                 categories.map {
+                GovernanceCouncilCategory(it.categoryId, it.categoryName)
+                    }
+             } catch (e: Exception) {
+                logger.error("Error mapping categories", e)
+              emptyList()
+             }
     }
 
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
@@ -2,7 +2,11 @@ package io.klaytn.finder.interfaces.rest.api.view.mapper
 
 import io.klaytn.commons.model.mapper.Mapper
 import io.klaytn.finder.domain.mysql.set1.governancecouncil.GovernanceCouncil
+import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilCategories
+import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilsInfo
+import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.GovernanceCouncilCategory
 import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.GovernanceCouncilView
+import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.GovernanceCouncilWithCategoryView
 import io.klaytn.finder.service.governancecouncil.GovernanceCouncilService
 import org.springframework.stereotype.Component
 
@@ -13,7 +17,7 @@ class GovernanceCouncilToViewMapper(
     override fun transform(source: GovernanceCouncil): GovernanceCouncilView {
         val governanceCouncilContractViews =
             governanceCouncilService.getGovernanceCouncilContracts(source.squareId)
-                .groupBy({it.addressType}, {it.address})
+                .groupBy({ it.addressType }, { it.address })
 
         return GovernanceCouncilView(
             squareId = source.squareId,
@@ -24,5 +28,31 @@ class GovernanceCouncilToViewMapper(
             contracts = governanceCouncilContractViews,
             joinedAt = source.joinedAt
         )
+    }
+}
+
+@Component
+class GovernanceCouncilToListViewMapper(
+) : Mapper<Pair<List<GovernanceCouncilsInfo>, List<GovernanceCouncilCategories>>, List<GovernanceCouncilWithCategoryView>> {
+    override fun transform(source: Pair<List<GovernanceCouncilsInfo>, List<GovernanceCouncilCategories>>): List<GovernanceCouncilWithCategoryView> {
+        val (governanceCouncilInfoList, governanceCouncilCategoriesList) = source
+
+        val governanceCouncilInfoMap = governanceCouncilInfoList.associateBy { it.squareId }
+        val governanceCouncilCategoriesMap = governanceCouncilCategoriesList.groupBy { it.squareId }
+
+        return governanceCouncilInfoMap.map { (squareId, governanceCouncilInfo) ->
+            val governanceCouncilCategories =
+                governanceCouncilCategoriesMap[squareId]?.map { GovernanceCouncilCategory(it.categoryId, it.categoryName) } ?: emptyList()
+            GovernanceCouncilWithCategoryView(
+                squareId = squareId,
+                name = governanceCouncilInfo.name,
+                squareLink = governanceCouncilInfo.squareLink,
+                thumbnail = governanceCouncilInfo.thumbnail,
+                totalStaking = governanceCouncilInfo.totalStaking,
+                apy = governanceCouncilInfo.apy,
+                description = governanceCouncilInfo.description,
+                categories = governanceCouncilCategories
+            )
+        }
     }
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/mapper/GovernanceCouncilToViewMapper.kt
@@ -41,13 +41,8 @@ class GovernanceCouncilToListViewMapper(
         val governanceCouncilCategoriesMap = governanceCouncilCategoriesList.groupBy { it.squareId }
 
         return governanceCouncilInfoMap.map { (squareId, governanceCouncilInfo) ->
-            val governanceCouncilCategories =
-                governanceCouncilCategoriesMap[squareId]?.map {
-                    GovernanceCouncilCategory(
-                        it.categoryId,
-                        it.categoryName
-                    )
-                } ?: emptyList()
+            val governanceCouncilCategories = this.mapCategories(governanceCouncilCategoriesMap[squareId] ?: emptyList())
+
             GovernanceCouncilWithCategoryView(
                 name = governanceCouncilInfo.name,
                 squareLink = governanceCouncilInfo.squareLink,
@@ -60,4 +55,11 @@ class GovernanceCouncilToListViewMapper(
             )
         }
     }
+
+    private fun mapCategories(categories: List<GovernanceCouncilCategories>): List<GovernanceCouncilCategory> {
+        return categories.map {
+            GovernanceCouncilCategory(it.categoryId, it.categoryName)
+        }
+    }
+
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/model/governancecouncil/GovernanceCouncilView.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/model/governancecouncil/GovernanceCouncilView.kt
@@ -22,11 +22,11 @@ data class GovernanceCouncilView(
 
 @Schema
 data class GovernanceCouncilWithCategoryView(
-    @JsonProperty("square_id") val squareId: Long,
     val name: String,
     @JsonProperty("square_link") val squareLink: String,
     val thumbnail: String,
     @JsonProperty("total_staking") val totalStaking: String,
+    val joinedAt: LocalDateTime?,
     val apy: String,
     val description: String,
     val categories: List<GovernanceCouncilCategory>,

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/model/governancecouncil/GovernanceCouncilView.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/api/view/model/governancecouncil/GovernanceCouncilView.kt
@@ -2,6 +2,7 @@ package io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
 import io.klaytn.finder.domain.common.GovernanceCouncilContractType
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
@@ -17,4 +18,22 @@ data class GovernanceCouncilView(
     val website: List<String>,
     val contracts: Map<GovernanceCouncilContractType, List<String>>,
     val joinedAt: LocalDateTime?,
+)
+
+@Schema
+data class GovernanceCouncilWithCategoryView(
+    @JsonProperty("square_id") val squareId: Long,
+    val name: String,
+    @JsonProperty("square_link") val squareLink: String,
+    val thumbnail: String,
+    @JsonProperty("total_staking") val totalStaking: String,
+    val apy: String,
+    val description: String,
+    val categories: List<GovernanceCouncilCategory>,
+)
+
+@Schema
+data class GovernanceCouncilCategory(
+    val id: Long,
+    val name: String
 )

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/papi/PapiGovernanceCouncilController.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/interfaces/rest/papi/PapiGovernanceCouncilController.kt
@@ -8,6 +8,7 @@ import io.klaytn.finder.service.GovernanceCouncilInfoService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
@@ -18,6 +18,8 @@ import io.klaytn.finder.infra.client.KaiaSquareGovernanceCouncilCommunity
 import io.klaytn.finder.infra.client.KaiaSquareGovernanceCouncilCommunityLink
 import io.klaytn.finder.infra.db.DbConstants
 import io.klaytn.finder.infra.utils.DateUtils
+import io.klaytn.finder.interfaces.rest.api.view.mapper.GovernanceCouncilToListViewMapper
+import io.klaytn.finder.interfaces.rest.api.view.model.governancecouncil.GovernanceCouncilWithCategoryView
 import io.klaytn.finder.service.governancecouncil.GovernanceCouncilCachedService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -292,4 +294,14 @@ class GovernanceCouncilInfoService(
                 null
             }
         }
+
+    fun getAll(): List<GovernanceCouncilWithCategoryView> {
+        val governanceCouncilInfo: List<GovernanceCouncilsInfo> = governanceCouncilsInfoRepository.findAll()
+        val governanceCouncilCategories: List<GovernanceCouncilCategories> = governanceCouncilCategoriesRepository.findAll()
+
+        val governanceListInfo = GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
+
+
+        return governanceListInfo
+    }
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
@@ -296,9 +296,14 @@ class GovernanceCouncilInfoService(
         }
 
     fun getAll(): List<GovernanceCouncilWithCategoryView> {
-        val governanceCouncilInfo: List<GovernanceCouncilsInfo> = governanceCouncilsInfoRepository.findAll()
-        val governanceCouncilCategories: List<GovernanceCouncilCategories> = governanceCouncilCategoriesRepository.findAll()
+        try {
+            val governanceCouncilInfo: List<GovernanceCouncilsInfo> = governanceCouncilsInfoRepository.findAll()
+            val governanceCouncilCategories: List<GovernanceCouncilCategories> = governanceCouncilCategoriesRepository.findAll()
 
-        return GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
+            return GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
+        } catch (e: Exception) {
+            logger.error("Failed to fetch governance council data", e)
+            throw e
+        }
     }
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
@@ -299,9 +299,6 @@ class GovernanceCouncilInfoService(
         val governanceCouncilInfo: List<GovernanceCouncilsInfo> = governanceCouncilsInfoRepository.findAll()
         val governanceCouncilCategories: List<GovernanceCouncilCategories> = governanceCouncilCategoriesRepository.findAll()
 
-        val governanceListInfo = GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
-
-
-        return governanceListInfo
+        return GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
     }
 }

--- a/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
+++ b/module-front-api/src/main/kotlin/io/klaytn/finder/service/GovernanceCouncilInfoService.kt
@@ -5,16 +5,8 @@ import io.klaytn.commons.utils.logback.logger
 import io.klaytn.commons.utils.retrofit2.orElseThrow
 import io.klaytn.finder.config.ClientProperties
 import io.klaytn.finder.domain.common.GovernanceCouncilContractType
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilsInfo
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilCategories
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilCommunities
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilContracts
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilsInfoRepository
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilCategoriesRepository
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilCommunitiesRepository
-import io.klaytn.finder.domain.mysql.set4.GovernanceCouncilContractsRepository
+import io.klaytn.finder.domain.mysql.set4.*
 import io.klaytn.finder.infra.client.KaiaSquareClient
-import io.klaytn.finder.infra.client.KaiaSquareGovernanceCouncilCommunity
 import io.klaytn.finder.infra.client.KaiaSquareGovernanceCouncilCommunityLink
 import io.klaytn.finder.infra.db.DbConstants
 import io.klaytn.finder.infra.utils.DateUtils
@@ -298,9 +290,15 @@ class GovernanceCouncilInfoService(
     fun getAll(): List<GovernanceCouncilWithCategoryView> {
         try {
             val governanceCouncilInfo: List<GovernanceCouncilsInfo> = governanceCouncilsInfoRepository.findAll()
-            val governanceCouncilCategories: List<GovernanceCouncilCategories> = governanceCouncilCategoriesRepository.findAll()
+            val governanceCouncilCategories: List<GovernanceCouncilCategories> =
+                governanceCouncilCategoriesRepository.findAll()
 
-            return GovernanceCouncilToListViewMapper().transform(Pair(governanceCouncilInfo, governanceCouncilCategories))
+            return GovernanceCouncilToListViewMapper().transform(
+                Pair(
+                    governanceCouncilInfo,
+                    governanceCouncilCategories
+                )
+            )
         } catch (e: Exception) {
             logger.error("Failed to fetch governance council data", e)
             throw e


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new endpoint `/api/v1/governance-councils` to retrieve governance council information.

- **Enhancements**
  - Governance council data now includes additional details such as `squareLink`, `totalStaking`, `apy`, `description`, and related categories.

- **Improvements**
  - Enhanced data mapping for governance council information for better structure and categorization.

- **Documentation**
  - Updated import statements to reflect new class and method additions for governance council information retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->